### PR TITLE
fix crash

### DIFF
--- a/src/components/TransactionInfo.js
+++ b/src/components/TransactionInfo.js
@@ -9,11 +9,7 @@ import BlueScoreContext from "./BlueScoreContext.js";
 import CopyButton from "./CopyButton.js";
 
 const getOutputFromIndex = (outputs, index) => {
-  for (const output of outputs) {
-    if (output.index === index) {
-      return output;
-    }
-  }
+  return outputs[index];
 };
 
 const TransactionInfo = () => {
@@ -184,12 +180,12 @@ const TransactionInfo = () => {
                                     additionalTxInfo[
                                       tx_input.previous_outpoint_hash
                                     ]?.outputs || [],
-                                    tx_input.previous_outpoint_index,
+                                    tx_input?.previous_outpoint_index,
                                   )?.amount || 0,
                               )
                               .reduce((a, b) => a + b) -
                               (
-                                txInfo.outputs?.map((v) => v.amount) || [0]
+                                txInfo.outputs?.map((v) => v?.amount) || [0]
                               ).reduce((a, b) => a + b)) /
                               100000000}{" "}
                             SPR
@@ -293,8 +289,8 @@ const TransactionInfo = () => {
                                   additionalTxInfo[
                                     tx_input.previous_outpoint_hash
                                   ].outputs,
-                                  tx_input.previous_outpoint_index,
-                                ).amount / 100000000}
+                                  tx_input?.previous_outpoint_index,
+                                )?.amount / 100000000}
                                 &nbsp;SPR
                               </span>
                             </div>
@@ -305,7 +301,7 @@ const TransactionInfo = () => {
                           Previous Outpoint Index + Hash
                         </div>
                         <div className="utxo-value-mono">
-                          #{tx_input.previous_outpoint_index}{" "}
+                          #{tx_input?.previous_outpoint_index}{" "}
                           {tx_input.previous_outpoint_hash}
                         </div>
                       </Col>
@@ -321,8 +317,8 @@ const TransactionInfo = () => {
                                       additionalTxInfo[
                                         tx_input.previous_outpoint_hash
                                       ].outputs,
-                                      tx_input.previous_outpoint_index,
-                                    ).script_public_key_address
+                                      tx_input?.previous_outpoint_index,
+                                    )?.script_public_key_address
                                   }`}
                                   className="blockinfo-link"
                                 >
@@ -331,8 +327,8 @@ const TransactionInfo = () => {
                                       additionalTxInfo[
                                         tx_input.previous_outpoint_hash
                                       ].outputs,
-                                      tx_input.previous_outpoint_index,
-                                    ).script_public_key_address
+                                      tx_input?.previous_outpoint_index,
+                                    )?.script_public_key_address
                                   }
                                 </Link>
                               </div>
@@ -366,7 +362,7 @@ const TransactionInfo = () => {
                         <div className="blockinfo-key mt-2 mt-lg-0">Amount</div>
                         <div className="utxo-value">
                           <span className="utxo-amount">
-                            +{numberWithCommas(tx_output.amount / 100000000)}
+                            +{numberWithCommas(tx_output?.amount / 100000000)}
                             &nbsp;SPR
                           </span>
                         </div>
@@ -385,10 +381,10 @@ const TransactionInfo = () => {
                         </div>
                         <div className="utxo-value-mono">
                           <Link
-                            to={`/addresses/${tx_output.script_public_key_address}`}
+                            to={`/addresses/${tx_output?.script_public_key_address}`}
                             className="blockinfo-link"
                           >
-                            {tx_output.script_public_key_address}
+                            {tx_output?.script_public_key_address}
                           </Link>
                         </div>
                       </Col>


### PR DESCRIPTION
- replaced manual looping with `outputs[index]` to directly access the array element
- added optional chaining (`?.`) to prevent crashes when `tx_output` or other objects might be `undefined` or `null`