### PR TITLE
added a button in `BlockOverview` to hide or show the `BlueScore` column and other improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spectre-explorer",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spectre-explorer",
-      "version": "0.3.15",
+      "version": "0.3.16",
       "hasInstallScript": true,
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spectre-explorer",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.1.2",

--- a/src/components/AddressInfo.js
+++ b/src/components/AddressInfo.js
@@ -89,20 +89,12 @@ const AddressInfo = () => {
     e.preventDefault();
   };
 
-  const getAddrFromOutputs = (outputs, i) => {
-    for (const o of outputs) {
-      if (o.index === i) {
-        return o.script_public_key_address;
-      }
-    }
+  const getAddrFromOutputs = (outputs, index) => {
+    return outputs?.[index]?.script_public_key_address;
   };
 
-  const getAmountFromOutputs = (outputs, i) => {
-    for (const o of outputs) {
-      if (o.index === i) {
-        return o.amount / 100000000;
-      }
-    }
+  const getAmountFromOutputs = (outputs, index) => {
+    return outputs?.[index]?.amount / 100000000;
   };
 
   const getAmount = (outputs, inputs) => {
@@ -122,7 +114,7 @@ const AddressInfo = () => {
         balance =
           balance -
           getAmountFromOutputs(
-            txsInpCache[i.previous_outpoint_hash]["outputs"],
+            txsInpCache[i.previous_outpoint_hash]?.outputs,
             i.previous_outpoint_index,
           );
       }
@@ -357,7 +349,6 @@ const AddressInfo = () => {
           </Col>
         </Row>
       </Container>
-
       {view === "transactions" && (
         <Container className="webpage addressinfo-box mt-4" fluid>
           <Row className="border-bottom border-bottom-1">
@@ -403,18 +394,15 @@ const AddressInfo = () => {
           {!loadingTxs ? (
             <>
               {txs.map((x) => (
-                <>
-                  <Row
-                    className="utxo-value text-primary mt-3"
-                    key={x.transaction_id}
-                  >
+                <div key={x.transaction_id}>
+                  <Row className="utxo-value text-primary mt-3">
                     <Col sm={7} md={7}>
                       {moment(x.block_time).format("YYYY-MM-DD HH:mm:ss")}
                     </Col>
                   </Row>
                   <Row className="pb-4 mb-0">
                     <Col sm={12} md={7}>
-                      <div className="utxo-header mt-3">transaction id</div>
+                      <div className="utxo-header mt-3">Transaction ID</div>
                       <div className="utxo-value-mono">
                         <Link
                           className="blockinfo-link"
@@ -425,7 +413,7 @@ const AddressInfo = () => {
                       </div>
                     </Col>
                     <Col sm={6} md={3}>
-                      <div className="utxo-header mt-3">amount</div>
+                      <div className="utxo-header mt-3">Amount</div>
                       <div className="utxo-value">
                         <Link
                           className="blockinfo-link"
@@ -451,12 +439,12 @@ const AddressInfo = () => {
                       </div>
                     </Col>
                     <Col sm={6} md={2}>
-                      <div className="utxo-header mt-3">value</div>
+                      <div className="utxo-header mt-3">Value</div>
                       <div className="utxo-value">
                         {numberWithCommas(
                           (getAmount(x.outputs, x.inputs) * price).toFixed(2),
                         )}{" "}
-                        $
+                        USD
                       </div>
                     </Col>
                   </Row>
@@ -470,8 +458,18 @@ const AddressInfo = () => {
                         >
                           {x.inputs?.length > 0
                             ? x.inputs.map((i) => {
-                                return txsInpCache &&
-                                  txsInpCache[i.previous_outpoint_hash] ? (
+                                const inputOutputs =
+                                  txsInpCache[i.previous_outpoint_hash]
+                                    ?.outputs || [];
+                                const address = getAddrFromOutputs(
+                                  inputOutputs,
+                                  i.previous_outpoint_index,
+                                );
+                                const amount = getAmountFromOutputs(
+                                  inputOutputs,
+                                  i.previous_outpoint_index,
+                                );
+                                return address ? (
                                   <Row
                                     id={`N${i.previous_outpoint_hash}${i.previous_outpoint_index}`}
                                     key={`${i.previous_outpoint_hash}${i.previous_outpoint_index}`}
@@ -482,40 +480,22 @@ const AddressInfo = () => {
                                     >
                                       <Link
                                         className="blockinfo-link"
-                                        to={`/addresses/${getAddrFromOutputs(txsInpCache[i.previous_outpoint_hash]["outputs"], i.previous_outpoint_index)}`}
+                                        to={`/addresses/${address}`}
                                       >
                                         <span
                                           className={
-                                            getAddrFromOutputs(
-                                              txsInpCache[
-                                                i.previous_outpoint_hash
-                                              ]["outputs"],
-                                              i.previous_outpoint_index,
-                                            ) === addr
+                                            address === addr
                                               ? "highlight-addr"
                                               : ""
                                           }
                                         >
-                                          {getAddrFromOutputs(
-                                            txsInpCache[
-                                              i.previous_outpoint_hash
-                                            ]["outputs"],
-                                            i.previous_outpoint_index,
-                                          )}
+                                          {address}
                                         </span>
                                       </Link>
                                     </Col>
                                     <Col xs={5}>
                                       <span className="block-utxo-amount-minus">
-                                        -
-                                        {numberWithCommas(
-                                          getAmountFromOutputs(
-                                            txsInpCache[
-                                              i.previous_outpoint_hash
-                                            ]["outputs"],
-                                            i.previous_outpoint_index,
-                                          ),
-                                        )}
+                                        -{numberWithCommas(amount)}
                                         &nbsp;SPR
                                       </span>
                                     </Col>
@@ -608,7 +588,7 @@ const AddressInfo = () => {
                       </Col>
                     </Row>
                   )}
-                </>
+                </div>
               ))}
               <Row>
                 <Col
@@ -652,6 +632,7 @@ const AddressInfo = () => {
           )}
         </Container>
       )}
+
       {view === "utxos" && (
         <Container className="webpage addressinfo-box mt-4" fluid>
           <Row className="border-bottom border-bottom-1">

--- a/src/components/BlockOverview.js
+++ b/src/components/BlockOverview.js
@@ -1,5 +1,7 @@
 import moment from "moment";
 import { useContext, useEffect, useRef, useState } from "react";
+import { OverlayTrigger, Tooltip } from "react-bootstrap";
+import { BiHide } from "react-icons/bi";
 import { FaDiceD20, FaPause, FaPlay } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
 import LastBlocksContext from "./LastBlocksContext";
@@ -10,12 +12,13 @@ const BlockOverview = (props) => {
   const { blocks, isConnected } = useContext(LastBlocksContext);
   const [tempBlocks, setTempBlocks] = useState([]);
   const [keepUpdating, setKeepUpdating] = useState(true);
+  const [showBlueScore, setShowBlueScore] = useState(true);
 
   const keepUpdatingRef = useRef();
   keepUpdatingRef.current = keepUpdating;
 
   const onClickRow = (e) => {
-    navigate(`/blocks/${e.target.parentElement.id}`);
+    navigate(`/blocks/${e.target.closest("tr").id}`);
   };
 
   useEffect(() => {
@@ -23,6 +26,10 @@ const BlockOverview = (props) => {
       setTempBlocks(blocks);
     }
   }, [blocks]);
+
+  const toggleBlueScore = () => {
+    setShowBlueScore(!showBlueScore);
+  };
 
   return (
     <div className="block-overview">
@@ -40,6 +47,22 @@ const BlockOverview = (props) => {
             onClick={() => setKeepUpdating(false)}
           />
         )}
+
+        <OverlayTrigger
+          overlay={
+            <Tooltip>{showBlueScore ? "Hide" : "Show"} BlueScore</Tooltip>
+          }
+        >
+          <span>
+            <BiHide
+              className={`mx-0 mt-3 hide-button ${
+                !showBlueScore && "hide-button-active"
+              }`}
+              onClick={toggleBlueScore}
+            />
+          </span>
+        </OverlayTrigger>
+
         <h4 className="block-overview-header text-center w-100 me-4">
           <FaDiceD20
             className={isConnected && keepUpdating ? "rotate" : ""}
@@ -54,7 +77,7 @@ const BlockOverview = (props) => {
           <thead>
             <tr>
               <th>Timestamp</th>
-              {props.small ? <></> : <th>BlueScore</th>}
+              {showBlueScore && <th>BlueScore</th>}
               <th>TXs</th>
               <th width="100%">Hash</th>
             </tr>
@@ -70,7 +93,7 @@ const BlockOverview = (props) => {
                       "YYYY‑MM‑DD HH:mm:ss",
                     )}
                   </td>
-                  {props.small ? <></> : <td>{x.blueScore}</td>}
+                  {showBlueScore && <td>{x.blueScore}</td>}
                   <td>{x.txCount}</td>
                   <td className="hashh">{x.block_hash}</td>
                 </tr>

--- a/src/components/TransactionInfo.js
+++ b/src/components/TransactionInfo.js
@@ -337,6 +337,20 @@ const TransactionInfo = () => {
                         )}
                     </Row>
                   ))}
+                  {(txInfo.inputs || []).length === 0 ? (
+                    <Row className="utxo-border py-3">
+                      <Col sm={12}>
+                        <div className="blockinfo-key mt-0 mt-md-2 me-auto">
+                          FROM
+                        </div>
+                        <div className="utxo-value mt-0 mt-md-2 me-auto">
+                          COINBASE ( New coins )
+                        </div>
+                      </Col>
+                    </Row>
+                  ) : (
+                    <></>
+                  )}
                 </Container>
                 <div className="blockinfo-header mt-5">
                   <h4>Outputs</h4>


### PR DESCRIPTION
* added a button in `BlockOverview` to hide or show the `BlueScore` column (same CSS rules as the `TxOverview` component for consistency) 08055da01f37b2103d539a7802381b567ad8a2fd
  * (it doesn't make sense to sort by timestamp because blocks can be merged in non-chronological order. Bluescore reflects the true order in the DAG.)
* cache `CoinsupplyBox.js` 84fc3b2a1e92460888622605e5b23d9989dd2087
  * updates the cached data every 60 seconds
* fixed coinbase input 841ac705e08e7889dca0bce9320fb846f5acdffa
*  fix crash in AddressInfoPage ba97820d1d27cdfe4ac5c03ac26d0e9175b23759
    * replaced manual looping with direct array access using `outputs[index]`
    * optional chaining (`?.`) to prevent crashes when objects like `tx_output` might be `undefined` or `null`