### PR TITLE
update DAG overview

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -332,7 +332,7 @@ body {
 
 .graph-container {
   width: 100%;
-  height: 600px;
+  height: 700px;
 }
 
 .row3 {

--- a/src/Dashboard.js
+++ b/src/Dashboard.js
@@ -28,7 +28,7 @@ function Dashboard() {
   const navigate = useNavigate();
 
   const handleClose = () => setShow(false);
-  const { blocks, isConnected } = useContext(LastBlocksContext);
+  const { blocks } = useContext(LastBlocksContext);
 
   const [showLoadingModal, setShowLoadingModal] = useState(false);
 

--- a/src/components/DAGGraph.js
+++ b/src/components/DAGGraph.js
@@ -9,34 +9,50 @@ const DAGGraph = ({ data, maxVisibleBlocks = 40 }) => {
 
   useEffect(() => {
     // calc visible blocks dynamically based on the screen width
-    const screenBlockLimit = Math.floor(window.innerWidth / 60);
+    const screenBlockLimit = Math.floor(window.innerWidth / 70); // may need some adjustment
     const visibleBlockCount = Math.min(maxVisibleBlocks, screenBlockLimit);
     const visibleBlocks = data.slice(-visibleBlockCount);
 
     // prepare nodes
     const nodes = visibleBlocks.map((block) => ({
       id: block.id,
-      label: `${block.id.substring(0, 9)}...`, // block hash
+      label: `${block.id.substring(0, 9)}...`, // blockhash length
       shape: "box",
       color: {
-        background: block.isChain ? "#e6e8ec" : "#ff005a",
+        background: block.isChain ? "#e6e8ec" : "#ff005a", // gray for chained, red for non-chained
         border: "#000",
       },
     }));
 
     // prepare edges
-    const edges = visibleBlocks.flatMap((block) =>
-      block.blueparents
+    const edges = visibleBlocks.flatMap((block) => {
+      // edges/arrows for blueparents
+      const blueEdges = block.blueparents
         ? block.blueparents
             .filter((parentId) => visibleBlocks.some((b) => b.id === parentId))
             .map((parentId) => ({
               from: parentId,
               to: block.id,
               arrows: "to",
-              color: "#e6e8ec",
+              color: "#5581aa", // blue merge set
             }))
-        : [],
-    );
+        : [];
+
+      // edges/arrows for redparents
+      const redEdges = block.redparents
+        ? block.redparents
+            .filter((parentId) => visibleBlocks.some((b) => b.id === parentId))
+            .map((parentId) => ({
+              from: parentId,
+              to: block.id,
+              arrows: "to",
+              color: "#ff005a", // red merge set
+            }))
+        : [];
+
+      // return blue and red edges
+      return [...blueEdges, ...redEdges];
+    });
 
     const dataSet = { nodes, edges };
 


### PR DESCRIPTION
* add DAG graph on the `BlockInfo` page
* white edges for connections to children blocks in the DAG graph on the `BlockInfo` page

in: `daggraph.js`
* logic for blue edges (arrows) to represent connections between a block and its blue merge set parent
* logic for red edges (arrows) to represent connections between a block and its red merge set parent