### PR TITLE
shorten block labels and other improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spectre-explorer",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spectre-explorer",
-      "version": "0.3.17",
+      "version": "0.3.18",
       "hasInstallScript": true,
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spectre-explorer",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.1.2",

--- a/src/App.js
+++ b/src/App.js
@@ -133,7 +133,7 @@ function App() {
     socket.emit("join-room", "bluescore");
 
     socket.on("new-block", (d) => {
-      setBlocks([...blocksRef.current, d].slice(-20));
+      setBlocks([...blocksRef.current, d].slice(-50));
     });
 
     return () => {

--- a/src/Dashboard.js
+++ b/src/Dashboard.js
@@ -61,7 +61,7 @@ function Dashboard() {
   };
 
   useEffect(() => {
-    if (blocks.length > 0) {
+    if (blocks && blocks.length > 0) {
       const latestBlock = blocks[blocks.length - 1];
       getDAGData(latestBlock);
     }

--- a/src/components/BlockInfo.js
+++ b/src/components/BlockInfo.js
@@ -50,7 +50,7 @@ const getAmountFromOutputs = (outputs, i) => {
 const createNodes = (blocks) => {
   return blocks.map((block) => ({
     id: block.id,
-    label: `${block.id.substring(0, 20)}`, // blockhash length
+    label: `${block.id.slice(0, 4)}\n${block.id.slice(4, 8)}`, // 4x4
     shape: "box",
     color: {
       background: block.isChain ? "#e6e8ec" : "#ff005a", // gray for chained, red for non-chained
@@ -230,7 +230,7 @@ const BlockInfo = () => {
             direction: "LR",
             sortMethod: "directed",
             nodeSpacing: 100,
-            levelSeparation: 150,
+            levelSeparation: 120,
           },
         },
         interaction: {
@@ -245,13 +245,13 @@ const BlockInfo = () => {
           borderWidth: 1,
           shape: "box",
           font: {
-            size: 14,
+            size: 18,
             face: "monospace",
             align: "center",
             color: "#000000",
           },
-          widthConstraint: 50,
-          heightConstraint: 50,
+          widthConstraint: 60,
+          heightConstraint: 60,
         },
         edges: {
           color: "#116466",

--- a/src/components/DAGGraph.js
+++ b/src/components/DAGGraph.js
@@ -9,14 +9,14 @@ const DAGGraph = ({ data, maxVisibleBlocks = 50 }) => {
 
   useEffect(() => {
     // calc visible blocks dynamically based on the screen width
-    const screenBlockLimit = Math.floor(window.innerWidth / 90); // may need some adjustment
+    const screenBlockLimit = Math.floor(window.innerWidth / 80); // may need some adjustment
     const visibleBlockCount = Math.min(maxVisibleBlocks, screenBlockLimit);
     const visibleBlocks = data.slice(-visibleBlockCount);
 
     // prepare nodes
     const nodes = visibleBlocks.map((block) => ({
       id: block.id,
-      label: `${block.id.substring(0, 22)}`, // blockhash length
+      label: `${block.id.slice(0, 4)}\n${block.id.slice(4, 8)}`, // 4x4
       shape: "box",
       color: {
         background: block.isChain ? "#e6e8ec" : "#ff005a", // gray for chained, red for non-chained
@@ -62,7 +62,7 @@ const DAGGraph = ({ data, maxVisibleBlocks = 50 }) => {
           direction: "LR",
           sortMethod: "directed",
           nodeSpacing: 100,
-          levelSeparation: 150,
+          levelSeparation: 120,
         },
       },
       interaction: {
@@ -80,7 +80,7 @@ const DAGGraph = ({ data, maxVisibleBlocks = 50 }) => {
         borderWidth: 1,
         shape: "box",
         font: {
-          size: 14,
+          size: 18,
           face: "monospace",
           align: "center",
           color: "#000000",


### PR DESCRIPTION
* this will display the first 8 characters of the blockhash and split into two lines of 4 characters each (4x4 format)

fixes:
* prevent premature `getBlock` calls
* limit `blocks` array to the last 50 blocks