### PR TITLE
retry logic for `getBlock`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,21 @@ written in JS with React.JS library.
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Features
+
+- Introduced DAG visualization using `vis-network`:
+
+  - Blocks/Nodes are color-coded:
+    - White ⚪: for blocks that are part of the Selected Parent Chain (SPC). These blocks are directly linked to their selected parents, eventually tracing back to the genesis block. They are considered part of the main consensus path in the DAG.
+    - Red 🔴: for blocks that are not part of the Selected Parent Chain (non-chained blocks). These blocks are valid within the DAG but do not belong to the SPC. They exist as alternative chains within the DAG, contributing to the structure but not directly influencing the main consensus path.
+
+  - Parent-child relationships between blocks are shown using edges (lines/arrows🏹 connecting blocks). These edges help visualize how blocks are related within the DAG:
+
+    - Blue 🔹: edges represent the relationship between a block and its blue merge set parent, which indicates that the block is part of the main blue chain in the DAG. This main chain includes both chained and non-chained blocks, all of which are considered honest and relevant to the consensus.
+    - Red 🔺: edges represent the connection between a block and its red merge set parent, which are blocks outside the main blue chain. These blocks are typically viewed as potential "attacker" blocks or blocks not part of the consensus, but they are still valid within the DAG. Red blocks are rare and do not influence the consensus chain directly.
+
+  - Clicking a block redirects to the BlockInfo page, which now also includes a static DAG graph
+
 ## Deployment
 
 For deploying the block explorer make sure that nodejs build

--- a/public/hashrate-data.json
+++ b/public/hashrate-data.json
@@ -916,7 +916,7 @@
     "Cores": "20",
     "Threads": "26",
     "Brand": "Intel",
-    "Model": "i7-14700k /only3.6ghz",
+    "Model": "i7-14700k / 3.6ghz",
     "RAM_size": "16GB",
     "RAM_frequency": "5600MHz",
     "Power_Reported": "",

--- a/src/components/AddressInfo.js
+++ b/src/components/AddressInfo.js
@@ -297,7 +297,7 @@ const AddressInfo = () => {
             <div className="addressinfo-header mt-4 ms-sm-5">UTXOs count</div>
             <div className="utxo-value ms-sm-5">
               {!loadingUtxos ? (
-                numberWithCommas(utxos.length)
+                utxos.length
               ) : (
                 <Spinner animation="border" variant="primary" />
               )}

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,12 +1,18 @@
 import { useEffect, useRef } from "react";
 
-export function numberWithCommas(x) {
-  if (x === undefined) {
-    return "";
-  }
-  var parts = x.toString().split(".");
-  parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-  return parts.join(".");
+export function numberWithCommas(num) {
+  const [integerPart, fractionalPart] = (num || "").toString().split(".");
+
+  if (!integerPart) return "0";
+
+  return (
+    <span>
+      <span>{integerPart.replace(/\B(?=(\d{3})+(?!\d))/g, ",")}</span>
+      {fractionalPart && (
+        <span style={{ fontSize: "80%" }}>.{fractionalPart}</span>
+      )}
+    </span>
+  );
 }
 
 export function floatToStr(floatNo, maxPrecision = 8) {
@@ -20,4 +26,5 @@ export function usePrevious(value) {
   }, [value]); //this code will run when the value of 'value' changes
   return ref.current; //in the end, return the current ref value.
 }
+
 export default usePrevious;


### PR DESCRIPTION
* if an error occurs, retries up to 5 times with exponential backoff (doubling delay each time)
* fixes an issue where a (404) error during `getBlock` would cause the DAG overview to split
* updated readme