### PR TITLE
testnet support and dynamic unit assignment for hashrate

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -80,11 +80,9 @@ function App() {
             navigate(`/blocks/${v}`);
           }
         })
-        .catch((err) => {
-          console.log("hier");
-        });
+        .catch((err) => {});
     }
-    if (v.startsWith("spectre:")) {
+    if (v.startsWith("spectre:") || v.startsWith("spectretest:")) {
       navigate(`/addresses/${v}`);
     }
 

--- a/src/Dashboard.js
+++ b/src/Dashboard.js
@@ -33,7 +33,7 @@ function Dashboard() {
   const [showLoadingModal, setShowLoadingModal] = useState(false);
 
   const balance = useState(0);
-  const address = useState("spectre:");
+  const address = useState("");
 
   const [ghostDAG, setGhostDAG] = useState([]);
 
@@ -107,12 +107,10 @@ function Dashboard() {
             navigate(`/blocks/${v}`);
           }
         })
-        .catch((err) => {
-          console.log("hier");
-        });
+        .catch((err) => {});
     }
 
-    if (v.startsWith("spectre:")) {
+    if (v.startsWith("spectre:") || v.startsWith("spectretest:")) {
       navigate(`/addresses/${v}`);
     }
 

--- a/src/components/AddressInfo.js
+++ b/src/components/AddressInfo.js
@@ -269,8 +269,13 @@ const AddressInfo = () => {
           <Col md={12} className="mt-sm-4">
             <div className="addressinfo-header">Address</div>
             <div className="utxo-value-mono">
-              <span className="addressinfo-color">spectre:</span>
-              {addr.substring(8, addr.length - 8)}
+              <span className="addressinfo-color">
+                {addr.startsWith("spectre:") ? "spectre:" : "spectretest:"}
+              </span>
+              {addr.substring(
+                addr.startsWith("spectre:") ? 8 : 12,
+                addr.length - 8,
+              )}
               <span className="addressinfo-color">
                 {addr.substring(addr.length - 8)}
               </span>


### PR DESCRIPTION
* dynamic unit assignment for hashrate (H/s, KH/s, MH/s, GH/s)
* converts a raw H/s into a human-readable format with appropriate units
* Mainnet and Testnet explorer support (`spectre:` and `spectretest:` prefixes)
* caching and periodic updates for maxHashrate
* cleaned up redundant logs in the code